### PR TITLE
fixed letter case typo in getSnapshotUrl

### DIFF
--- a/R/checkpoint.R
+++ b/R/checkpoint.R
@@ -234,7 +234,7 @@ checkpoint <- function(snapshotDate, project = getwd(), R.version, scanForPackag
 #  ------------------------------------------------------------------------
 
 
-setMranMirror <- function(snapshotDate, snapshotUrl = checkpoint:::getSnapShotUrl(snapshotDate)){
+setMranMirror <- function(snapshotDate, snapshotUrl = checkpoint:::getSnapshotUrl(snapshotDate)){
   options(repos = snapshotUrl)}
 
 setLibPaths <- function(checkpointLocation, libPath){


### PR DESCRIPTION
With mistyped second "s" (to capital "S") in getSnapshotUrl the `getOptions("repos")` were not updated to MRAN. Thus the packages were installed directly from CRAN, defeating the purpose of the `checkpoint` utility.