### PR TITLE
fix vignette entry title

### DIFF
--- a/vignettes/managing-checkpoint-archives.Rmd
+++ b/vignettes/managing-checkpoint-archives.Rmd
@@ -8,7 +8,7 @@ output:
     number_sections: true
     keep_md: yes
 vignette: >
-  %\VignetteIndexEntry{Using checkpoint for reproducible research}
+  %\VignetteIndexEntry{Managing checkpoint snapshot archives}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
the vignette entry title was incorrect (duplicated from another vignette). These titles appear (among other places) on the CRAN webpage: https://cran.r-project.org/web/packages/checkpoint/index.html