### PR TITLE
Skip http tests if as-cran is true.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,8 @@ Description: The goal of checkpoint is to solve the problem of package
     server (<https://mran.microsoft.com/>). Immediately after completion
     of the rsync mirror process, the process takes a snapshot, thus creating the
     archive. Snapshot archives exist starting from 2014-09-17.
-Version: 0.4.3
-Date: 2017-12-15
+Version: 0.4.4
+Date: 2018-03-23
 Author: Microsoft Corporation
 Maintainer: Rich Calaway <richcala@microsoft.com>
 Copyright: Microsoft

--- a/tests/testthat/test-0-is-404.R
+++ b/tests/testthat/test-0-is-404.R
@@ -5,6 +5,7 @@ context("is.404")
 
 test_that("is.404", {
   skip_if_offline()
+  skip_on_cran()
   expect_true(
     is.404("http://mran.microsoft.com/snapshot/1972-01-01", warn = FALSE)
   )


### PR DESCRIPTION
Added to prevent http tests failing on R CMD check when running with 'as-cran' flag.
If as-cran flag is true, skip the failing tests.

