### PR TITLE
Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ env:
   - NOT_CRAN="true"
   - NOT_CRAN="false"
 
-branches:
-  only:
-    - master
-    - release
-    - dev
-    
 notifications:
   email:
     on_success: change

--- a/R/checkpoint.R
+++ b/R/checkpoint.R
@@ -233,14 +233,14 @@ checkpoint <- function(snapshotDate, project = getwd(),
         )
       }
     }
-  } else if(length(packages.detected > 0)){
+  } else if(length(packages.detected) > 0){
     mssg(verbose, "All detected packages already installed")
   } else {
     if(isTRUE(scanForPackages)) mssg(verbose, "No packages found to install")
   }
   
   # Reload detached packages
-  if(length(packages.in.search > 0)){
+  if(length(packages.in.search) > 0){
     lapply(packages.in.search, library, character.only = TRUE, quietly = TRUE)
   }
   

--- a/R/checkpoint.R
+++ b/R/checkpoint.R
@@ -171,7 +171,7 @@ checkpoint <- function(snapshotDate, project = getwd(),
     files.not.parsed <- character(0)
   }
   
-  if(forceInstall && packages.detected > 0){
+  if(forceInstall && length(packages.detected) > 0){
     mssg(verbose, "Removing packages to force re-install")
     to_remove <- as.vector(unlist(
       tools::package_dependencies(packages.detected, db = available.packages())
@@ -199,7 +199,7 @@ checkpoint <- function(snapshotDate, project = getwd(),
     # set repos
     setMranMirror(snapshotUrl = snapshoturl)
     not.available <- !packages.to.install %in% available.packages()[, "Package"]
-    if(sum(not.available > 0)){
+    if(sum(not.available) > 0){
       mssg(verbose, 
            "Packages not available in repository and won't be installed:")
       for(pkg in packages.to.install[not.available]) mssg(verbose, " - ", pkg)

--- a/R/checkpoint_internals.R
+++ b/R/checkpoint_internals.R
@@ -35,7 +35,7 @@ unCheckpoint <- function(new){
   }
   if(!is.null(internal$oldLibPaths)) {
     .libPaths(internal$oldLibPaths)
-    rm(oldLibPaths, envir=internal)
+    rm(list="oldLibPaths", envir=internal)
   }
   invisible(NULL)
 }

--- a/R/checkpoint_internals.R
+++ b/R/checkpoint_internals.R
@@ -1,13 +1,15 @@
 
-setMranMirror <- function(
-  snapshotDate, 
-  snapshotUrl = checkpoint:::getSnapshotUrl(snapshotDate)){
+setMranMirror <- function(snapshotDate, snapshotUrl = checkpoint:::getSnapshotUrl(snapshotDate))
+{
   options(repos = snapshotUrl)
 }
 
 
+internal <- new.env()
+
 setLibPaths <- function(checkpointLocation, libPath){
-  newLoc <- c(libPath, 
+  internal$oldLibPaths <- .libPaths()
+  newLoc <- c(libPath,
               checkpointBasePkgs(checkpointLocation),
               .Library
               )
@@ -16,20 +18,26 @@ setLibPaths <- function(checkpointLocation, libPath){
 
 
 #' Undo the effect of checkpoint by resetting .libPath to user library location.
-#' 
-#' @description 
-#' 
-#' This is an experimental solution to the situation where a user no longer wants to work in the checkpointed environment. The function resets [.libPaths] to point two libraries defined by the environment variable `R_Libs_User` and the R variable `.Library`.
+#'
+#' @description
+#'
+#' This is an experimental solution to the situation where a user no longer wants to work in the checkpointed environment. The function resets [.libPaths] to its pre-checkpoint value.
 #' 
 #' Note that this does not undo any of the other side-effects of [checkpoint()]. Specifically, all loaded packages remain loaded, and the value of `getOption("repos")` remains unchanged.
-#' 
+#'
 #' @param new The new user library location. Defaults to `c(Sys.getenv("R_Libs_User"), .Library)`. See also [.libPaths()]
-#' 
+#'
 #' @export
 #' @family checkpoint functions
-unCheckpoint <- function(new = c(Sys.getenv("R_LIBS_USER"), .Library)){
-  assign(".lib.loc", new, 
-         envir = environment(.libPaths))
+unCheckpoint <- function(new){
+  if(!missing(new)) {
+    warning("'new' argument is no longer used; unCheckpoint will automatically revert to pre-checkpoint library paths")
+  }
+  if(!is.null(internal$oldLibPaths)) {
+    .libPaths(internal$oldLibPaths)
+    rm(oldLibPaths, envir=internal)
+  }
+  invisible(NULL)
 }
 
 

--- a/man/unCheckpoint.Rd
+++ b/man/unCheckpoint.Rd
@@ -4,13 +4,13 @@
 \alias{unCheckpoint}
 \title{Undo the effect of checkpoint by resetting .libPath to user library location.}
 \usage{
-unCheckpoint(new = c(Sys.getenv("R_LIBS_USER"), .Library))
+unCheckpoint(new)
 }
 \arguments{
 \item{new}{The new user library location. Defaults to \code{c(Sys.getenv("R_Libs_User"), .Library)}. See also \code{\link[=.libPaths]{.libPaths()}}}
 }
 \description{
-This is an experimental solution to the situation where a user no longer wants to work in the checkpointed environment. The function resets \link{.libPaths} to point two libraries defined by the environment variable \code{R_Libs_User} and the R variable \code{.Library}.
+This is an experimental solution to the situation where a user no longer wants to work in the checkpointed environment. The function resets \link{.libPaths} to its pre-checkpoint value.
 
 Note that this does not undo any of the other side-effects of \code{\link[=checkpoint]{checkpoint()}}. Specifically, all loaded packages remain loaded, and the value of \code{getOption("repos")} remains unchanged.
 }

--- a/tests/testthat/test-0-is-404.R
+++ b/tests/testthat/test-0-is-404.R
@@ -3,9 +3,11 @@ library(mockery)
 
 context("is.404")
 
+skip("testing")
+
 test_that("is.404", {
   skip_if_offline()
-  skip_on_cran()
+
   expect_true(
     is.404("http://mran.microsoft.com/snapshot/1972-01-01", warn = FALSE)
   )
@@ -15,11 +17,10 @@ test_that("is.404", {
   expect_false(
     is.404("http://mran.microsoft.com/snapshot/2015-05-01")
   )
-  stop("this is an error!")
 })
 
 test_that("is.404 works with https", {
-  skip_on_cran()
+
   if(!httpsSupported()) skip("https not supported")
   expect_true(
     suppressWarnings(is.404("https://mran.microsoft.com/snapshot/1972-01-01"))
@@ -34,7 +35,7 @@ test_that("is.404 works with https", {
 })
 
 test_that("is.404 gracefully deals with https URLs when https not supported", {
-  skip_on_cran()
+
   stub(is.404, "httpsSupported", function(mran) FALSE)
   expect_true(
     is.404("https://mran.microsoft.com/snapshot/1972-01-01", warn = FALSE)
@@ -53,7 +54,7 @@ test_that("is.404 gracefully deals with https URLs when https not supported", {
 })
 
 test_that("is.404() deals with local file references", {
-  skip_on_cran()
+
   localMRAN <- system.file("tests/localMRAN", package = "checkpoint")
   msg <- "Ensure you use the correct http://,  https:// or file:/// prefix."
   expect_error(is.404(localMRAN), msg)

--- a/tests/testthat/test-0-is-404.R
+++ b/tests/testthat/test-0-is-404.R
@@ -17,7 +17,6 @@ test_that("is.404", {
   expect_false(
     is.404("http://mran.microsoft.com/snapshot/2015-05-01")
   )
-  stop("this is an error!")
 })
 
 test_that("is.404 works with https", {

--- a/tests/testthat/test-0-is-404.R
+++ b/tests/testthat/test-0-is-404.R
@@ -17,6 +17,7 @@ test_that("is.404", {
   expect_false(
     is.404("http://mran.microsoft.com/snapshot/2015-05-01")
   )
+  stop("this is an error!")
 })
 
 test_that("is.404 works with https", {

--- a/tests/testthat/test-0-is-404.R
+++ b/tests/testthat/test-0-is-404.R
@@ -3,7 +3,7 @@ library(mockery)
 
 context("is.404")
 
-skip_on_cran()
+skip("explicit skip")
 
 test_that("is.404", {
   skip_if_offline()

--- a/tests/testthat/test-0-is-404.R
+++ b/tests/testthat/test-0-is-404.R
@@ -3,8 +3,6 @@ library(mockery)
 
 context("is.404")
 
-skip_on_cran()
-
 test_that("is.404", {
   skip_if_offline()
   skip_on_cran()
@@ -21,7 +19,7 @@ test_that("is.404", {
 })
 
 test_that("is.404 works with https", {
-  
+  skip_on_cran()
   if(!httpsSupported()) skip("https not supported")
   expect_true(
     suppressWarnings(is.404("https://mran.microsoft.com/snapshot/1972-01-01"))
@@ -36,7 +34,7 @@ test_that("is.404 works with https", {
 })
 
 test_that("is.404 gracefully deals with https URLs when https not supported", {
-  
+  skip_on_cran()
   stub(is.404, "httpsSupported", function(mran) FALSE)
   expect_true(
     is.404("https://mran.microsoft.com/snapshot/1972-01-01", warn = FALSE)
@@ -55,6 +53,7 @@ test_that("is.404 gracefully deals with https URLs when https not supported", {
 })
 
 test_that("is.404() deals with local file references", {
+  skip_on_cran()
   localMRAN <- system.file("tests/localMRAN", package = "checkpoint")
   msg <- "Ensure you use the correct http://,  https:// or file:/// prefix."
   expect_error(is.404(localMRAN), msg)

--- a/tests/testthat/test-0-is-404.R
+++ b/tests/testthat/test-0-is-404.R
@@ -3,7 +3,7 @@ library(mockery)
 
 context("is.404")
 
-skip("testing")
+skip_on_cran()
 
 test_that("is.404", {
   skip_if_offline()

--- a/tests/testthat/test-0-is-404.R
+++ b/tests/testthat/test-0-is-404.R
@@ -3,7 +3,7 @@ library(mockery)
 
 context("is.404")
 
-skip("explicit skip")
+skip_on_cran()
 
 test_that("is.404", {
   skip_if_offline()

--- a/tests/testthat/test-0-snapshots.R
+++ b/tests/testthat/test-0-snapshots.R
@@ -23,7 +23,7 @@ test_that("stops if invalid snapshotDate format", {
 })
 
 test_that("stops if snapshotDate doesn't exist on MRAN", {
-  
+
   expect_error(
     checkpoint("2014-09-16"), 
     "Snapshots are only available after 2014-09-17"
@@ -35,34 +35,30 @@ test_that("stops if snapshotDate doesn't exist on MRAN", {
 })
 
 test_that("set http/https correctly", {
-  skip_on_cran()
-  skip_if_offline()
-  test_that("resolves to http/https based on R version number", {
-    if(getRversion() >= "3.2.0"  && httpsSupported()){
-      expect_warning(
-        getSnapshotUrl("1972-01-01"), 
-        "Unable to find snapshot on MRAN at https://mran.microsoft.com/snapshot/1972-01-01"
-      )
-    } else {
-      expect_warning(
-        getSnapshotUrl("1972-01-01"), 
-        "Unable to find snapshot on MRAN at http://mran.microsoft.com/snapshot/1972-01-01"
-      )
-    }
-    
-    dd <- "2014-09-08"
-    mm <- getSnapshotUrl(dd)
-    expect_equal(paste0(mranUrl(), dd), mm)
-    
-    url <- mranUrl()
-    if(getRversion() >= "3.2.0"  && httpsSupported()){
-      expect_equal(url, "https://mran.microsoft.com/snapshot/")
-    } else {
-      expect_equal(url, "http://mran.microsoft.com/snapshot/")
-    }
-    
-  })
-})  
+
+  if(getRversion() >= "3.2.0"  && httpsSupported()){
+    expect_warning(
+      getSnapshotUrl("1972-01-01"),
+      "Unable to find snapshot on MRAN at https://mran.microsoft.com/snapshot/1972-01-01"
+    )
+  } else {
+    expect_warning(
+      getSnapshotUrl("1972-01-01"),
+      "Unable to find snapshot on MRAN at http://mran.microsoft.com/snapshot/1972-01-01"
+    )
+  }
+
+  dd <- "2014-09-08"
+  mm <- getSnapshotUrl(dd)
+  expect_equal(paste0(mranUrl(), dd), mm)
+
+  url <- mranUrl()
+  if(getRversion() >= "3.2.0"  && httpsSupported()){
+    expect_equal(url, "https://mran.microsoft.com/snapshot/")
+  } else {
+    expect_equal(url, "http://mran.microsoft.com/snapshot/")
+  }
+})
 
 unCheckpoint()
 

--- a/tests/testthat/test-3-checkpoint.R
+++ b/tests/testthat/test-3-checkpoint.R
@@ -7,6 +7,7 @@ if(interactive()) library(testthat)
 Sys.setenv("R_TESTS" = "")
 
 current.R <- local({ x = getRversion(); paste(x$major, x$minor, sep=".")})
+originalLibPaths <- .libPaths()
 
 test.start <- switch(current.R,
                      "3.1" = "2014-10-01",
@@ -30,8 +31,6 @@ dir.create(file.path(checkpointLocation, ".checkpoint"), recursive = TRUE, showW
 
 test_checkpoint <- function(https = FALSE, snap_date){
   # snap_date <- test.start
-  
-  originalLibPaths <- .libPaths()
   
   url_prefix <- if(https) "https://" else "http://"
   # url_prefix <- "http://"
@@ -58,7 +57,7 @@ test_checkpoint <- function(https = FALSE, snap_date){
       "No packages found to install"
     )
     
-    unCheckpoint(originalLibPaths)
+    unCheckpoint()
   })
   
   # expect_true(length(find.package("knitr", quiet = TRUE)) > 0)
@@ -89,7 +88,7 @@ test_checkpoint <- function(https = FALSE, snap_date){
     )
     
     # prints progress message
-    unCheckpoint(originalLibPaths)
+    unCheckpoint()
     expect_message(
       checkpoint(snap_date, project = project_root,
                  checkpointLocation = checkpointLocation, use.knitr = TRUE),
@@ -127,7 +126,7 @@ test_checkpoint <- function(https = FALSE, snap_date){
     messageMissingPackages(expected.packages, pkgNames(pdbLocal))
     
     # re-installs packages when forceInstall=TRUE
-    unCheckpoint(originalLibPaths)
+    unCheckpoint()
     expect_message(
       checkpoint(snap_date,
                  checkpointLocation = checkpointLocation,
@@ -162,7 +161,7 @@ test_checkpoint <- function(https = FALSE, snap_date){
   test_that(paste("checkpoint -", sub("//", "", url_prefix), "@", snap_date, "other tests"), {
     
     # does not display message whan scanForPackages=FALSE
-    unCheckpoint(originalLibPaths)
+    unCheckpoint()
     expect_false(
       isTRUE(
         shows_message("Scanning for packages used in this project",
@@ -172,7 +171,7 @@ test_checkpoint <- function(https = FALSE, snap_date){
       ))
     
     # throws error when scanForPackages=FALSE and snapshotDate doesn't exist"
-    unCheckpoint(originalLibPaths)
+    unCheckpoint()
     expect_error(
       checkpoint("2015-01-01", checkpointLocation = checkpointLocation,
                  project = project_root, scanForPackages=FALSE),
@@ -180,7 +179,7 @@ test_checkpoint <- function(https = FALSE, snap_date){
     )
     
     # stops when R.version doesn't match current version
-    unCheckpoint(originalLibPaths)
+    unCheckpoint()
     expect_error(
       checkpoint(snap_date, R.version = "2.15.0",
                  checkpointLocation = checkpointLocation,
@@ -192,7 +191,7 @@ test_checkpoint <- function(https = FALSE, snap_date){
   test_that(paste("checkpoint -", sub("//", "", url_prefix), "@", snap_date, "cleanup"), {
     # cleanup
     cleanCheckpointFolder(snap_date, checkpointLocation = checkpointLocation)
-    unCheckpoint(originalLibPaths)
+    unCheckpoint()
     expect_identical(originalLibPaths, .libPaths())
   })
 }


### PR DESCRIPTION
- Fix errors picked up by R CMD check
- Make `unCheckpoint` always restore pre-checkpoint paths