### PR TITLE
update testing for new pkgcache behaviour

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,3 +1,6 @@
+withr::local_envvar(R_USER_CACHE_DIR=tempfile(), .local_envir=teardown_env())
+
+
 list_pkgsrc <- function(snapshot_dir)
 {
     pkgs <- dir(snapshot_dir, full.names=TRUE)


### PR DESCRIPTION
This PR fixes the tests to handle the changed pkgcache behaviour in version 1.2.2.