### PR TITLE
Add option to ignore packages during checkpoint setup.

### DIFF
--- a/R/checkpoint.R
+++ b/R/checkpoint.R
@@ -31,6 +31,8 @@
 #'
 #' @param config A named list of additional configuration options to pass to [`pkgdepends::new_pkg_installation_proposal`]. See 'Configuration' below.
 #'
+#' @param ignore_packages A character vector of packages to ignore when creating a checkpoint. This can also be set globally using `options('checkpoint.ignorePackages' = c('package'))`.
+#'
 #' @param ... For `checkpoint`, further arguments to pass to `create_checkpoint` and `use_checkpoint`. Ignored for `create_checkpoint` and `use_checkpoint`.
 #'
 #' @param confirm For `delete_checkpoint` and `delete_all_checkpoints`, whether to ask for confirmation first.
@@ -102,6 +104,7 @@ create_checkpoint <- function(snapshot_date,
                               log=TRUE,
                               num_workers=getOption("Ncpus", 1),
                               config=list(),
+                              ignore_packages=getOption("checkpoint.ignorePackages"),
                               ...
                              )
 {
@@ -133,6 +136,11 @@ create_checkpoint <- function(snapshot_date,
     {
         warning("No package dependencies found", call.=FALSE)
         return(invisible(NULL))
+    }
+    # ignore select packages
+    if(!is.null(ignore_packages))
+    {
+        dep_list$pkgs = setdiff(dep_list$pkgs, ignore_packages)
     }
 
     # install packages

--- a/man/checkpoint.Rd
+++ b/man/checkpoint.Rd
@@ -30,6 +30,7 @@ create_checkpoint(
   log = TRUE,
   num_workers = getOption("Ncpus", 1),
   config = list(),
+  ignore_packages = getOption("checkpoint.ignorePackages"),
   ...
 )
 
@@ -81,6 +82,8 @@ uncheckpoint()
 \item{num_workers}{The number of parallel workers to use for installing packages. Defaults to the value of the system option \code{Ncpus}, or if this is unset, 1.}
 
 \item{config}{A named list of additional configuration options to pass to \code{\link[pkgdepends:new_pkg_installation_proposal]{pkgdepends::new_pkg_installation_proposal}}. See 'Configuration' below.}
+
+\item{ignore_packages}{A character vector of packages to ignore when creating a checkpoint. This can also be set globally using \code{options('checkpoint.ignorePackages' = c('package'))}.}
 
 \item{prepend}{If \code{TRUE}, adds the checkpoint directory to the beginning of the library search path. The default is \code{FALSE}, where the checkpoint directory replaces all but the system entries (the values of \code{.Library} and \code{.Library.site}) in the search path; this is to reduce the chances of accidentally calling non-checkpointed code. See \code{\link{.libPaths}}.}
 


### PR DESCRIPTION
Hello! 

I was testing out the version 1.0.0 release, and I came across a use-case that I think this simple PR can help solve.

# Issue

My organization uses internal packages, and the issue is that `checkpoint` will fail with an error if a non-CRAN package is scanned in the code. I could not find a way to tell `checkpoint` to ignore certain libraries when creating the checkpoint, nor could I find any open or closed issues relevant to this. This is tangentially related to #203 insofar as it will at least allow checkpoint to proceed if any non-CRAN packages are in use in the project. 

# Solution

This PR adds an argument `ignore_packages` to `create_checkpoint`, with a default arg set to read an R option, that returns NULL by default. If `ignore_packages` is supplied, those packages will be removed from the result of `scan_project_files` before it is sent to `install_pkgs`. I added the option so that it might be inserted in the project .Rprofile. This is essentially what I would have to do anyway if I were to manually prevent checkpoint from attempting to install certain packages.

# Other comments

Of course the onus would then be on the user to properly stabilize package versions for those ignored packages, but I think that that is easy enough for Github packages by using the `remotes` package referencing a commit hash regarding #203. 