### PR TITLE
Save logs as rds

### DIFF
--- a/R/install_pkgs.R
+++ b/R/install_pkgs.R
@@ -46,11 +46,10 @@ write_checkpoint_log <- function(object, name, checkpoint_location, logtime, do_
         return(invisible(NULL))
 
     logtime <- strftime(logtime, "%Y%m%d_%H%M%S")
-    name <- paste0(logtime, "_", name, ".json")
+    name <- paste0(logtime, "_", name, ".rds")
     pathname <- file.path(checkpoint_location, ".checkpoint", name)
-    object <- rm_conditions(object)
 
-    writeLines(jsonlite::toJSON(object, auto_unbox=TRUE, pretty=TRUE, null="null", force=TRUE), pathname)
+    saveRDS(object, pathname)
     invisible(object)
 }
 
@@ -65,15 +64,20 @@ warn_for_install_error <- function(install_result)
     NULL
 }
 
-# remove condition objects in results before logging
-rm_conditions <- function(x)
-{
-    x[] <- if(!is.list(x))
-        x
-    else if(inherits(x, "condition"))
-        "<error>"
-    else if(is.recursive(x))
-        lapply(x, rm_conditions)
-    else x
-    x
-}
+# # remove condition objects in results before logging
+# rm_conditions_and_functions <- function(x)
+# {
+#     if(is.environment(x))
+#         x <- as.list(x)
+#     else if(typeof(x) %in% c("closure", "builtin"))
+#         return(NULL)
+
+#     x[] <- if(!is.list(x))
+#         x
+#     else if(inherits(x, "condition"))
+#         "<error>"
+#     else if(is.recursive(x))
+#         lapply(x, rm_conditions_and_functions)
+#     else x
+#     x
+# }


### PR DESCRIPTION
Instead of serialising the output objects from pkgdepends as json, simply save them as rds files. This is because pkgdepends has recently changed the format of some of these objects to be environments, rather than simple data frames or lists. While this is a richer format, it means serialisation to text is now tricky and error-prone.

Since checkpoint is an R package and anyone interacting with it can be assumed to know R, this change should be safe.

Fixes #312 